### PR TITLE
mmr gas tests

### DIFF
--- a/ethereum/test/test_mmr_verification_gas.js
+++ b/ethereum/test/test_mmr_verification_gas.js
@@ -1,0 +1,61 @@
+const BigNumber = require('bignumber.js');
+const { mergeKeccak256 } = require('./helpers');
+
+require("chai")
+  .use(require("chai-as-promised"))
+  .use(require("chai-bignumber")(BigNumber))
+  .should();
+
+const MMRVerification = artifacts.require("MMRVerification");
+const SimpleMMRVerification = artifacts.require("SimplifiedMMRVerification");
+const fixture15leaves = require('./fixtures/mmr-fixture-data-15-leaves.json');
+const fixture15leavesSimplified = require('./fixtures/simplified-mmr-fixture-data-15-leaves.json');
+
+describe("SimpleMMRVerification Contract", function () {
+  describe("15-leaf, 26-node MMR", function () {
+
+    context("15-leaf MMR from fixture gas tests", function () {
+
+      let simplifiedMMRVerification;
+      beforeEach(async function () {
+        simplifiedMMRVerification = await SimpleMMRVerification.new();
+      })
+
+      fixture15leavesSimplified.proofs.forEach((proof, i) => {
+        it(`should verify valid proof for leaf index ${i}`, async () => {
+          const gas = await simplifiedMMRVerification.verifyInclusionProof.estimateGas(
+            fixture15leavesSimplified.rootHash, fixture15leavesSimplified.leaves[i],
+            {
+              restOfThePeaks: fixture15leavesSimplified.proofs[i].mmrRestOfThePeaks,
+              rightBaggedPeak: fixture15leavesSimplified.proofs[i].mmrRightBaggedPeak,
+              merkleProofItems: fixture15leavesSimplified.proofs[i].merkleProofItems,
+              merkleProofOrderBitField: fixture15leavesSimplified.proofs[i].merkleProofOrder
+            })
+          console.log(`Gas used: ${gas}`);
+        });
+      });
+
+    });
+  });
+});
+
+describe("MMRVerification Contract", function () {
+  describe("15-leaf, 26-node MMR", function () {
+
+    context("15-leaf MMR from fixture gas tests", function () {
+      let mmrVerification;
+      beforeEach(async function () {
+        mmrVerification = await MMRVerification.new();
+      })
+
+      fixture15leaves.proofs.forEach((proof, i) => {
+        it(`should verify valid proof for leaf index ${i}`, async () => {
+          const gas = await mmrVerification.verifyInclusionProof.estimateGas(
+            fixture15leaves.rootHash, fixture15leaves.leaves[i],
+            proof.leafIndex, proof.leafCount, proof.items);
+          console.log(`Gas used: ${gas}`);
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
Looks like 90% gas costs cut :D :D 

```
➜  ethereum git:(add-simplified-proof) ✗ npx hardhat test ./test/test_mmr_verification_gas.js


  SimpleMMRVerification Contract
    15-leaf, 26-node MMR
      15-leaf MMR from fixture gas tests
The Hardhat Network tracing engine could not be initialized. Run Hardhat with --verbose to learn more.
Gas used: 33103
        ✓ should verify valid proof for leaf index 0 (72ms)
Gas used: 33135
        ✓ should verify valid proof for leaf index 1 (41ms)
Gas used: 33135
        ✓ should verify valid proof for leaf index 2
Gas used: 33155
        ✓ should verify valid proof for leaf index 3
Gas used: 33135
        ✓ should verify valid proof for leaf index 4
Gas used: 33155
        ✓ should verify valid proof for leaf index 5
Gas used: 33143
        ✓ should verify valid proof for leaf index 6
Gas used: 33163
        ✓ should verify valid proof for leaf index 7
Gas used: 33843
        ✓ should verify valid proof for leaf index 8
Gas used: 33875
        ✓ should verify valid proof for leaf index 9
Gas used: 33875
        ✓ should verify valid proof for leaf index 10
Gas used: 33895
        ✓ should verify valid proof for leaf index 11
Gas used: 34539
        ✓ should verify valid proof for leaf index 12
Gas used: 34571
        ✓ should verify valid proof for leaf index 13
Gas used: 33799
        ✓ should verify valid proof for leaf index 14

  MMRVerification Contract
    15-leaf, 26-node MMR
      15-leaf MMR from fixture gas tests
Gas used: 363789
        ✓ should verify valid proof for leaf index 0 (921ms)
Gas used: 364134
        ✓ should verify valid proof for leaf index 1 (949ms)
Gas used: 365189
        ✓ should verify valid proof for leaf index 2 (899ms)
Gas used: 363444
        ✓ should verify valid proof for leaf index 3 (854ms)
Gas used: 369980
        ✓ should verify valid proof for leaf index 4 (889ms)
Gas used: 370296
        ✓ should verify valid proof for leaf index 5 (889ms)
Gas used: 367328
        ✓ should verify valid proof for leaf index 6 (875ms)
Gas used: 363059
        ✓ should verify valid proof for leaf index 7 (871ms)
Gas used: 297813
        ✓ should verify valid proof for leaf index 8 (874ms)
Gas used: 298084
        ✓ should verify valid proof for leaf index 9 (856ms)
Gas used: 299427
        ✓ should verify valid proof for leaf index 10 (869ms)
Gas used: 297442
        ✓ should verify valid proof for leaf index 11 (860ms)
Gas used: 227054
        ✓ should verify valid proof for leaf index 12 (831ms)
Gas used: 227274
        ✓ should verify valid proof for leaf index 13 (833ms)
Gas used: 151322
        ✓ should verify valid proof for leaf index 14 (133ms)


  30 passing (14s)
```